### PR TITLE
Annotate special glyphs

### DIFF
--- a/source/annotate.hs
+++ b/source/annotate.hs
@@ -115,9 +115,9 @@ symDecode img (x, y) (w, h)
   | isOperator = SymOperator value
   | isBox = SymBox (w-2) (h-2) boxValue
   | isEllipsis = SymEllipsis
-  | checkSymbol img symOpenPar (x-1, y-1) = SymSpecial "<"
-  | checkSymbol img symClosePar (x-1, y-1) = SymSpecial ">"
-  | checkSymbol img symPipe (x-1, y-1) = SymSpecial "|"
+  | checkSymbol img symOpenPar (x-1, y-1) = SymSpecial "("
+  | checkSymbol img symClosePar (x-1, y-1) = SymSpecial ")"
+  | checkSymbol img symPipe (x-1, y-1) = SymSpecial ","
   | otherwise = SymUnknown
   where
     size = w

--- a/source/annotate.hs
+++ b/source/annotate.hs
@@ -105,6 +105,9 @@ imgAllPixels img = range2d 0 0 (imgWidth img - 1) (imgHeight img - 1)
 
 symDecode :: Img -> Coord -> Size -> Symbol
 symDecode img (x, y) (w, h)
+  | checkSymbol img symGalaxy (x, y) = SymSpecial "galaxy"
+  | checkSymbol img symHuman (x, y) = SymSpecial "human"
+  | checkSymbol img symSpacecraft (x, y) = SymSpecial "spacecraft"
   | isNonNegativeNumber = SymNumber value
   | isNegativeNumber = SymNumber (-value)
   | isModulatedNumber = SymModulatedNumber modulatedValue
@@ -198,6 +201,9 @@ symDetectSingle img (x, y)
   | checkSymbol img symOpenPar (x-1, y-1) = Just (3, 5)
   | checkSymbol img symClosePar (x-1, y-1) = Just (3, 5)
   | checkSymbol img symPipe (x-1, y-1) = Just (2, 5)
+  | checkSymbol img symGalaxy (x, y) = Just (7, 7)
+  | checkSymbol img symHuman (x, y) = Just (7, 7)
+  | checkSymbol img symSpacecraft (x, y) = Just (7, 7)
   | otherwise = Nothing
   where
     px x' y' = imgPixel img (x + x', y + y')
@@ -258,6 +264,39 @@ symPipe = map (map (=='#'))
   , ".##."
   , ".##."
   , "...."
+  ]
+
+symGalaxy :: [[Bool]]
+symGalaxy = map (map (=='#'))
+  [ "..###.."
+  , ".....#."
+  , ".###..#"
+  , "#.#.#.#"
+  , "#..###."
+  , " #....."
+  , "..###.."
+  ]
+
+symHuman :: [[Bool]]
+symHuman = map (map (=='#'))
+  [ "..#.#.."
+  , "..#.#.."
+  , "..###.."
+  , "..###.."
+  , "..###.."
+  , "#######"
+  , "...#..."
+  ]
+
+symSpacecraft :: [[Bool]]
+symSpacecraft = map (map (=='#'))
+  [ "...#..."
+  , ".#####."
+  , ".#...#."
+  , "##...##"
+  , "##.#.##"
+  , ".#####."
+  , "#.#.#.#"
   ]
 
 checkLine :: Img -> [Bool] -> Coord -> Bool


### PR DESCRIPTION
* Parens: `(` `,` `)`
* Boxes (like in message 41): `#width:height:hex-encoded-data`, e.g. `#17:13:20002800000011`
* `galaxy` (img 42), `human` (img 15), `spacecraft` (img 15)
* Fix vars (#47)